### PR TITLE
Update util.py

### DIFF
--- a/src/renpy/util.py
+++ b/src/renpy/util.py
@@ -26,11 +26,9 @@ def get_code_properties(props: tuple | dict, newline: bool = False) -> str:
     list = []
     if isinstance(props, dict):
         props = props.items()
-    for k, v in props:
-        if v is None:
-            list.append(k)
-        else:
-            list.append(f"{k} {v}")
+    for prop in props:
+        prop_str = " ".join([str(x) for x in prop if x is not None])
+        list.append(prop_str)
     return ("\n" if newline else " ").join(list)
 
 


### PR DESCRIPTION
Fixed get_code_properties to accept tuples of any size in the props parameter, instead of only 2.
Examples (found in real games):

```
[('linear', '0.5'), ('alpha', '1.0', None)]
[('zoom', '2', None)]
```

Also ignoring None on any position to make it congruent with the function docstring, because the second usage example implies a (None, "b") should return "b" and the current implementation returns "None b".