### PR TITLE
Fix extract-translate command and AST AttributeError

### DIFF
--- a/src/renpy/ast.py
+++ b/src/renpy/ast.py
@@ -103,13 +103,15 @@ class Node(object):
 
     @name.setter
     def name(self, value: str | tuple[Any, ...] | None):
-        match value:
-            case (self.filename, int(version), int(serial)):
-                self._name = None
-                self.name_version = version
-                self.name_serial = serial
-            case _:
-                self._name = value
+        if hasattr(self, "filename"):
+            match value:
+                case (self.filename, int(version), int(serial)):
+                    self._name = None
+                    self.name_version = version
+                    self.name_serial = serial
+                    return
+
+        self._name = value
 
     def __init__(self, loc: tuple[str, int] = ("", 0)):
         """

--- a/src/rpycdec/cli.py
+++ b/src/rpycdec/cli.py
@@ -77,6 +77,16 @@ def main():
         required=True,
         help="directory to save translations",
     )
+    extract_translate_parser.add_argument(
+        "--src-lang",
+        default="en",
+        help="source language (default: en)",
+    )
+    extract_translate_parser.add_argument(
+        "--dest-lang",
+        required=True,
+        help="destination language",
+    )
     extract_translate_parser.set_defaults(
         func=lambda args: run_extract_translations(args.src, args.output, **vars(args))
     )


### PR DESCRIPTION
This PR addresses several issues preventing the extract-translate command from functioning correctly:

1. **Fix AttributeError in renpy.ast.Node**:
   - Added a safety check for self.filename in the 
ame setter. Previously, accessing self.filename when it wasn't set caused a crash during decompilation of certain files.

2. **Fix extract_translate function signature**:
   - Updated 
pycdec.translate.extract_translate to match the arguments passed by the CLI. It now correctly accepts game_dir, output_dir, and **kwargs.

3. **Enhance CLI with Language Arguments**:
   - Added --src-lang (default: 'en') and --dest-lang (required) arguments to the extract-translate command.
   - This allows users to specify the target language for the translation block (e.g., 	ranslate <lang> strings:), making the tool language-agnostic.

4. **Implement String Extraction and Saving**:
   - The tool now iterates through the AST, collects translatable strings, and saves them to extracted_strings.rpy in the specified output directory.
   - Added error handling to skip individual files that fail to process (e.g., due to get_code errors), ensuring the extraction process completes for the remaining files.